### PR TITLE
Expose messages on queue for testing purposes

### DIFF
--- a/NetSQS.Mock.Tests/MockTests.cs
+++ b/NetSQS.Mock.Tests/MockTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Amazon.SQS.Model;
 using Xunit;
@@ -171,6 +172,21 @@ namespace NetSQS.Mock.Tests
 
             Assert.Equal(1, queuesOnClientBeforeDeletion.Count);
             Assert.Equal(0, queuesOnClientAfterDeletion.Count);
+        }
+
+        [Fact]
+        public async Task MockGetMessagesOnQueue_ShouldContainSentMessage_WhenQueueExists()
+        {
+            var queueName = "mockQueue.fifo";
+            var messageContents = "Hello World!";
+            var client = new SQSClientMock("mockEndpoint", "mockRegion");
+            await client.CreateStandardFifoQueueAsync(queueName);
+            await client.SendMessageAsync(messageContents, queueName);
+
+            var actual = client.GetMessages(queueName);
+
+            Assert.Equal(1, actual.Count);
+            Assert.Equal(messageContents, actual.First());
         }
     }
 }

--- a/NetSQS.Mock.sln
+++ b/NetSQS.Mock.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29318.209
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetSQS.Mock", "NetSQS.Mock.csproj", "{9B789F79-4E44-4577-883E-04DE6BC8B437}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetSQS.Mock", "NetSQS.Mock\NetSQS.Mock.csproj", "{9B789F79-4E44-4577-883E-04DE6BC8B437}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetSQS.Mock.Tests", "..\NetSQS.Mock.Tests\NetSQS.Mock.Tests.csproj", "{3DC294BC-C46B-40AD-AD96-DD903AEFEF34}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetSQS.Mock.Tests", "NetSQS.Mock.Tests\NetSQS.Mock.Tests.csproj", "{3DC294BC-C46B-40AD-AD96-DD903AEFEF34}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/NetSQS.Mock/SQSClientMock.cs
+++ b/NetSQS.Mock/SQSClientMock.cs
@@ -22,6 +22,11 @@ namespace NetSQS.Mock
             };
         }
 
+        public Queue<string> GetMessages(string queueName)
+        {
+            return MockClientObject.Queues[queueName];
+        }
+
         public async Task<string> SendMessageAsync(string message, string queueName)
         {
             MockClientObject.Queues.TryGetValue(queueName, out var queue);


### PR DESCRIPTION
Added GetMessages to SQSClientMock that returns the current in-memory queue contents.
Fixed invalid paths in solution file.